### PR TITLE
Update dependencies for release

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/"
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.7/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.7/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.7/"
   }
 }

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.10/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.10/mod.ts"
   }
 }


### PR DESCRIPTION
Update the following dependencies for the upcoming release:

- `deno_slack_api` - (`0.0.7`)

Also removed the `--unstable` flag to reflect previous removal in other repositories.