### PR TITLE
Update README to include more info for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ When instantiating the function, use `SlackFunctionHandler` and pass
 in your function's `.definition` so that your required inputs and outputs will be 
 enforced.
 
-
 ## Using the CLI
 To learn more about development with the CLI, you can visit the following guides:
 - [In-depth guide on Creating a New App](https://api.slack.com/future/create)

--- a/README.md
+++ b/README.md
@@ -236,7 +236,22 @@ export default myFunction;
 A function's implementation must be the default export of the source file. 
 When instantiating the function, use `SlackFunctionHandler` and pass 
 in your function's `.definition` so that your required inputs and outputs will be 
-enforced. 
+enforced.
+
+
+## Using the CLI
+To learn more about development with the CLI, you can visit the following guides:
+- [In-depth guide on Creating a New App](https://api.slack.com/future/create)
+- [Configuring an app](https://api.slack.com/future/manifest)
+- [Developing locally](https://api.slack.com/future/run)
+To view all documentation and guides available for the CLI, visit the [Overview page](https://api.slack.com/future/overview).
+
+When using the CLI to develop your app, here are some helpful commands:
+- `slack version`: Checks current version of your CLI and the SDKs it uses.
+- `slack upgrade`: Checks for updates for current SDK and CLI versions and upgrades them as needed.
+- `slack auth list`: Lists all authorized workspaces.
+- `slack auth login`: Allows you to log in to a new or inactive workspace with the CLI.
+To view all other commands available in the CLI, run `slack help`.
 
 ## Running your app locally
 


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

Based on current ongoing discussions, I am updating the Deno Starter Template to include more information and resources for the CLI. All feedback is welcome! Would love to get specific feedback on:
- This placement of info in the README
- Whether there's info I should remove
- If there is any info I should add!

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
