### PR TITLE
Add example for Datastores in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ $ deno test
 
 ## Datastores
 
-If your app needs to store any data, a datastore would be the right place for that. For an example of a datastore, see `datastores/sample_datastore.ts`. Remember to add the `datastores:write`/`datastores:read` scopes and uncomment the `datastores` key in your manifest file if you are using a datastore.
+If your app needs to store any data, a datastore would be the right place for
+that. For an example of a datastore, see `datastores/sample_datastore.ts`.
+Remember to add the `datastores:write`/`datastores:read` scopes and uncomment
+the `datastores` key in your manifest file if you are using a datastore.
 
 ## Deploying Your App
 
@@ -168,7 +171,8 @@ such as a user pressing a button or when a specific event occurs.
 
 ### `/datastores`
 
-[Datastores](https://api.slack.com/future/datastores) are a Slack-hosted location to store and retrieve data for your next-generation apps.
+[Datastores](https://api.slack.com/future/datastores) are a Slack-hosted
+location to store and retrieve data for your next-generation apps.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CLI.
 - [Create a Link Trigger](#create-a-link-trigger)
 - [Running Your Project Locally](#running-your-project-locally)
 - [Testing](#testing)
+- [Datastores](#datastores)
 - [Deploying Your App](#deploying-your-app)
   - [Viewing Activity Logs](#viewing-activity-logs)
 - [Project Structure](#project-structure)
@@ -106,6 +107,10 @@ Run all tests with `deno test`:
 $ deno test
 ```
 
+## Datastores
+
+If your app needs to store any data, a datastore would be the right place for that. For an example of a datastore, see `datastores/sample_datastore.ts`. Remember to add the `datastores:write`/`datastores:read` scopes and uncomment the `datastores` key in your manifest file if you are using a datastore.
+
 ## Deploying Your App
 
 Once you're done with development, you can deploy the production version of your
@@ -160,6 +165,10 @@ to the next step.
 [Triggers](https://api.slack.com/future/triggers) determine when Workflows are
 executed. A trigger file describes a scenario in which a workflow should be run,
 such as a user pressing a button or when a specific event occurs.
+
+### `/datastores`
+
+[Datastores](https://api.slack.com/future/datastores) are a Slack-hosted location to store and retrieve data for your next-generation apps.
 
 ## Resources
 

--- a/datastores/sample_datastore.ts
+++ b/datastores/sample_datastore.ts
@@ -1,0 +1,18 @@
+import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+
+/**
+ * Datastores are a Slack-hosted location to store and retrieve 
+ * data for your next-generation apps.
+ * https://api.slack.com/future/datastores
+ */
+const SampleDatastore = DefineDatastore({
+  name: "sample_datastore",
+  primary_key: "id",
+  attributes: {
+    id: {
+      type: Schema.types.string,
+    },
+  },
+});
+
+export default SampleDatastore;

--- a/datastores/sample_datastore.ts
+++ b/datastores/sample_datastore.ts
@@ -1,7 +1,7 @@
 import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
 
 /**
- * Datastores are a Slack-hosted location to store and retrieve 
+ * Datastores are a Slack-hosted location to store and retrieve
  * data for your next-generation apps.
  * https://api.slack.com/future/datastores
  */

--- a/manifest.ts
+++ b/manifest.ts
@@ -12,5 +12,6 @@ export default Manifest({
   icon: "assets/icon.png",
   workflows: [SampleWorkflow],
   outgoingDomains: [],
+  // datastores: [SampleDatastore], 
   botScopes: ["commands", "chat:write", "chat:write.public"],
 });

--- a/manifest.ts
+++ b/manifest.ts
@@ -12,6 +12,6 @@ export default Manifest({
   icon: "assets/icon.png",
   workflows: [SampleWorkflow],
   outgoingDomains: [],
-  // datastores: [SampleDatastore], 
+  // datastores: [SampleDatastore],
   botScopes: ["commands", "chat:write", "chat:write.public"],
 });


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR adds an example of using Datastores as well as some information on Datastores within the README. The datastore itself isn't actually used within the app, so it only exists as an example to be overwritten by the developer.  The Welcome Bot sample app shows an example of using the datastore in context, so I think that example is best for developers to reference but let me know otherwise!

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
