### PR TITLE
Gracefully handle errors from the `datastore.put` response

### DIFF
--- a/functions/sample_function.ts
+++ b/functions/sample_function.ts
@@ -60,12 +60,18 @@ export default SlackFunction(
 
     // Save the sample object to the datastore
     // https://api.slack.com/automation/datastores
-    await client.apps.datastore.put<typeof SampleObjectDatastore.definition>(
-      {
-        datastore: "SampleObjects",
-        item: sampleObject,
-      },
-    );
+    const putResponse = await client.apps.datastore.put<
+      typeof SampleObjectDatastore.definition
+    >({
+      datastore: "SampleObjects",
+      item: sampleObject,
+    });
+
+    if (!putResponse.ok) {
+      return {
+        error: `Failed to put item into the datastore: ${putResponse.error}`,
+      };
+    }
 
     return { outputs: { updatedMsg } };
   },

--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -1,5 +1,9 @@
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+} from "https://deno.land/std@0.153.0/testing/asserts.ts";
 import SampleFunction from "./sample_function.ts";
 import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 
@@ -8,9 +12,14 @@ const { createContext } = SlackFunctionTester("sample_function");
 // Replaces globalThis.fetch with the mocked copy
 mf.install();
 
-mf.mock("POST@/api/apps.datastore.put", () => {
+// Shared mocks can be defined at the top level of tests
+mf.mock("POST@/api/apps.datastore.put", async (args) => {
+  const body = await args.formData();
+  const datastore = body.get("datastore");
+  const item = body.get("item");
+
   return new Response(
-    `{"ok": true, "item": {"object_id": "d908f8bd-00c6-43f0-9fc3-4da3c2746e14"}}`,
+    `{"ok": true, "datastore": ${datastore}, "item": ${item}}`,
     {
       status: 200,
     },
@@ -19,9 +28,27 @@ mf.mock("POST@/api/apps.datastore.put", () => {
 
 Deno.test("Sample function test", async () => {
   const inputs = { message: "Hello, World!", user: "U01234567" };
-  const { outputs } = await SampleFunction(createContext({ inputs }));
-  await assertEquals(
+  const { outputs, error } = await SampleFunction(createContext({ inputs }));
+
+  assertEquals(error, undefined);
+  assertEquals(
     outputs?.updatedMsg,
     ":wave: <@U01234567> submitted the following message: \n\n>Hello, World!",
   );
+});
+
+Deno.test("Sample function datastore error handling", async () => {
+  // Mocks specific to a test can be overriden within a test
+  mf.mock("POST@/api/apps.datastore.put", () => {
+    return new Response(`{"ok": false, "error": "datastore_error"}`, {
+      status: 200,
+    });
+  });
+
+  const inputs = { message: "Hello, World!", user: "U01234567" };
+  const { outputs, error } = await SampleFunction(createContext({ inputs }));
+
+  assertExists(error);
+  assertStringIncludes(error, "datastore_error");
+  assertEquals(outputs, undefined);
 });

--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -19,7 +19,7 @@ mf.mock("POST@/api/apps.datastore.put", async (args) => {
   const item = body.get("item");
 
   return new Response(
-    `{"ok": true, "datastore": ${datastore}, "item": ${item}}`,
+    `{"ok": true, "datastore": "${datastore}", "item": ${item}}`,
     {
       status: 200,
     },


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR adds error handling to the `datastore.put` call, returning an error if this call is unsuccessful. Related tests are also added.

Unsure if this is the ideal way to mock different responses or if this is how we'd like to handle this error case, so please feel free to suggest alternatives!

### Notes

Mocked responses were updated to match https://api.slack.com/methods/apps.datastore.put#examples

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
