### PR TITLE
Import external dependencies with the import map

### DIFF
--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -3,9 +3,9 @@ import {
   assertEquals,
   assertExists,
   assertStringIncludes,
-} from "https://deno.land/std@0.153.0/testing/asserts.ts";
+} from "std/testing/asserts.ts";
 import SampleFunction from "./sample_function.ts";
-import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+import * as mf from "mock-fetch/mod.ts";
 
 const { createContext } = SlackFunctionTester("sample_function");
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,8 @@
 {
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.4.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.1.2/"
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.1.2/",
+    "std/": "https://deno.land/std@0.183.0/",
+    "mock-fetch/": "https://deno.land/x/mock_fetch@0.3.0/"
   }
 }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR moves module imports into the `import_map.json` file for easier updating.

### Notes

- An update to the deno-sample-dependencies repo will follow!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)