### PR TITLE
Update std assertions import in sample test

### DIFF
--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertExists,
   assertStringIncludes,
-} from "std/testing/asserts.ts";
+} from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import SampleFunction from "./sample_function.ts";
 import * as mf from "mock-fetch/mod.ts";
 


### PR DESCRIPTION
Use the deno-land import, to avoid deprecation warnings

### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

tl;dr: use import from deno-land for test assertions

I'm currently learning to create Slack Workflow apps, and while setting up a new project using this template, vs code showed me warnings about the assertions being deprecated. 
While following the documentation for [custom functions](https://api.slack.com/automation/functions/custom) I noticed that the import for the assertions in the [test tutorial](https://api.slack.com/automation/functions/custom#testing) was different than the one in this template. 
I tried updating to the import used in the tutorial, and that got rid of the deprecation warnings.

<img width="761" alt="Code snippet, asserts strike through, marked as deprecated" src="https://github.com/user-attachments/assets/cdeb11ec-c7f4-42f9-b46d-a550eb2f43f0">

_I decided to use latest deno std version at the time of writing (0.224.0), but we might want to be consistent with the version in the tutorial?_

### Requirements (place an x in each [ ] that applies)

- [ ] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
