### PR TITLE
Update std assertions import

### DIFF
--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertExists,
   assertStringIncludes,
-} from "std/testing/asserts.ts";
+} from "std/assert/mod.ts";
 import SampleFunction from "./sample_function.ts";
 import * as mf from "mock-fetch/mod.ts";
 


### PR DESCRIPTION
Use the new assert import format to avoid deprecation warnings

### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

According to the documentation the import for the asserts should be `https://deno.land/std/assert/mod.ts`
Source: https://deno.land/std@0.224.0/testing/asserts.ts

I first solved this wrongly in #72 (more details in that PR), I think this is the way it should be. But while we're at it, we might as well switch the example to `jsr:` 🤷🏻 

My VSCode marked the assertions as deprecated, and it was a bit confusing as a new developer on the slack apps.

### Requirements (place an x in each [ ] that applies)

- [ ] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
