### PR TITLE
build: add deno installation directory to devcontainer path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,7 @@ USER slackdev
 
 # Install the project runtime
 RUN curl -fsSL https://deno.land/install.sh | sh
-RUN export DENO_INSTALL="/home/slackdev/.deno"
-RUN export PATH="$DENO_INSTALL/bin:$PATH"
+ENV PATH="/home/slackdev/.deno/bin:$PATH"
 
 # Set the working directory
 WORKDIR /workspaces


### PR DESCRIPTION
### Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR was created to resolve Issue #85 and allow developers to use deno commands from their dev container terminal without manual intervention.

This fix, if approved, should be applied across all Deno sample apps that include the same dev container Dockerfile.

### Requirements

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
